### PR TITLE
Add DNS seeder

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1139,7 +1139,7 @@ void MapPort()
 // The first name is used as information source for addrman.
 // The second name should resolve to a list of seed addresses.
 static const char *strDNSSeed[][2] = {
-    {"23.254.97.249", "23.254.97.249"}, //Main Kobocoin Seed Node
+    {"alltheco.in", "kobo.alltheco.in"}, //Main Kobocoin Seed Node
 };
 
 void ThreadDNSAddressSeed(void* parg)


### PR DESCRIPTION
Clients will connect to a DNS seeder to get a list of other clients on the network to connect to. A DNS seeder will crawl the network and compile a list of good clients to serve to others as nodes for connectivity.

DNS Seeder for Kobocoin
https://github.com/Bushstar/koboseeder/