### PR TITLE
Add obj folders for compilation

### DIFF
--- a/src/obj-test/.gitignore
+++ b/src/obj-test/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/obj/.gitignore
+++ b/src/obj/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Without these folders errors are generated on some systems during compilation.